### PR TITLE
Small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In node repl
 
 ```js
 fs = require('fs/promises')
-content = await fs.readFile('./e2aP_1F3G.pdb', encoding='utf8')
+content = await fs.readFile('./e2aP_1F3G.pdb', encoding='ascii')
 pdbtbx = await import('./pkg/pdbtbx_ts.js')
 > info = pdbtbx.open_pdb(content)
 PDBInfo { ptr: 1114120 }


### PR DESCRIPTION
Some small changes I found while going through your code.
* PDB files are defined to be `ASCII`
* You made a new empty struct `PDBError` and never returned it in the `open_pdb` function. I changed it to `Result<PDBInfo, String` and created a single string from all errors.
* Some small rusty code style updates.